### PR TITLE
Integrate login and board QML

### DIFF
--- a/qml/ChessGame.qml
+++ b/qml/ChessGame.qml
@@ -1,38 +1,34 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
+import "../qt" as Ui
 
 ApplicationWindow {
     id: root
     visible: true
-    width: 480
-    height: 480
+    width: 1920
+    height: 1080
     title: "Chess"
 
-    property int whiteTime: 600
-    property int blackTime: 600
+    property bool inGame: false
 
-    Timer {
-        id: turnTimer
-        interval: 1000
-        running: true
-        repeat: true
-        onTriggered: {
-            if (game.sideToMove === "White")
-                whiteTime--
-            else
-                blackTime--
-            if (whiteTime <= 0 || blackTime <= 0) {
-                turnTimer.stop()
-                game.timeOut()
-            }
+    Loader {
+        id: pageLoader
+        anchors.fill: parent
+        sourceComponent: inGame ? gamePage : loginPage
+    }
+
+    Component {
+        id: loginPage
+        Ui.Screen01 {
+            id: loginScreen
+            login_button.onClicked: root.inGame = true
         }
     }
 
-    Column {
-        anchors.centerIn: parent
-        spacing: 10
-        Text { text: "White: " + whiteTime }
-        Text { text: "Black: " + blackTime }
-        Button { text: "Resign"; onClicked: game.resign() }
+    Component {
+        id: gamePage
+        Ui.Game_board {
+            anchors.fill: parent
+        }
     }
 }

--- a/qt/Game_board.ui.qml
+++ b/qt/Game_board.ui.qml
@@ -12,6 +12,25 @@ Item {
     id: root
     width: 1920
     height: 1080
+    property int whiteTime: 600
+    property int blackTime: 600
+
+    Timer {
+        id: turnTimer
+        interval: 1000
+        running: true
+        repeat: true
+        onTriggered: {
+            if (game.sideToMove === "White")
+                whiteTime--
+            else
+                blackTime--
+            if (whiteTime <= 0 || blackTime <= 0) {
+                turnTimer.stop()
+                game.timeOut()
+            }
+        }
+    }
 
     BorderImage {
         id: borderImage
@@ -320,6 +339,28 @@ Item {
                 fillMode: Image.PreserveAspectFit
             }
 
+        }
+    }
+
+    Column {
+        id: timerDisplay
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.margins: 20
+        spacing: 4
+        Text { text: "White: " + whiteTime }
+        Text { text: "Black: " + blackTime }
+    }
+
+    Button {
+        id: resignButton
+        text: qsTr("Resign")
+        anchors.bottom: parent.bottom
+        anchors.right: parent.right
+        anchors.margins: 20
+        onClicked: {
+            turnTimer.stop()
+            game.resign()
         }
     }
 }


### PR DESCRIPTION
## Summary
- hook up new QML pages and switch between login and board
- add resign button and game timer to the board screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68505a870c5883208e2dba8ecc001332